### PR TITLE
Set ruby image version to 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:2.1
 MAINTAINER Education Team at Docker <education@docker.com>
 
 COPY . /src


### PR DESCRIPTION
The build doesn't complete with latest ruby. See https://github.com/jpetazzo/container.training/issues/141  but it works with 2.1, so let's use 2.1.